### PR TITLE
Fix compilation when not using ZLIB

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -67,6 +67,8 @@
 #    define _FILE_OFFSET_BITS 0
 #  endif
 #  include <zlib.h>
+#else
+typedef void* gzFile;
 #endif
 
 /****************************************************************************************\


### PR DESCRIPTION
When USE_ZLIB is set to 0, gzFile must be defined to void*